### PR TITLE
Remove deprecated `Beaker.experiment.await_all()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- Removed deprecated `Beaker.experiment.await_all()` method.
+
 ## [v0.15.3](https://github.com/allenai/beaker-py/releases/tag/v0.15.3) - 2022-05-10
 
 ### Added

--- a/beaker/services/experiment.py
+++ b/beaker/services/experiment.py
@@ -312,23 +312,6 @@ class ExperimentClient(ServiceClient):
             assert job.execution is not None  # for mypy
             return self.beaker.dataset.get(job.execution.result.beaker)
 
-    def await_all(
-        self,
-        *experiments: Union[str, Experiment],
-        timeout: Optional[float] = None,
-        poll_interval: float = 1.0,
-        quiet: bool = False,
-    ) -> List[Experiment]:
-        import warnings
-
-        warnings.warn(
-            "'ExperimentClient.await_all()' is deprecated. Please use 'ExperimentClient.wait_for()' instead.",
-            DeprecationWarning,
-        )
-        return self.wait_for(
-            *experiments, timeout=timeout, poll_interval=poll_interval, quiet=quiet
-        )
-
     def wait_for(
         self,
         *experiments: Union[str, Experiment],

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ Contents
 Team
 ----
 
-**beaker-py** is developed and maintained by the `AllenNLP <https://allenai.org/allennlp>`_ and ReViz teams at
+**beaker-py** is developed and maintained at
 `the Allen Institute for Artificial Intelligence (AI2) <https://allenai.org/>`_.
 AI2 is a non-profit institute with the mission to contribute to humanity through high-impact AI research and engineering.
 


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #78 