### PR TITLE
Add export_experiments method to GroupClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `Beaker.group.export_experiments()` method.
+
 ### Fixed
 
 - Fixed `Job` priority validation.

--- a/beaker/progress.py
+++ b/beaker/progress.py
@@ -106,6 +106,16 @@ def get_logs_progress(quiet: bool = False) -> Progress:
     )
 
 
+def get_group_experiments_progress(quiet: bool = False) -> Progress:
+    return Progress(
+        "[progress.description]{task.description}",
+        SpinnerColumn(),
+        FileSizeColumn(),
+        TimeElapsedColumn(),
+        disable=quiet,
+    )
+
+
 def get_exps_and_jobs_progress(quiet: bool = False) -> Tuple[Live, Progress, Progress]:
     experiments_progress = get_experiments_progress(quiet)
     jobs_progress = get_jobs_progress(quiet)

--- a/beaker/services/group.py
+++ b/beaker/services/group.py
@@ -190,6 +190,23 @@ class GroupClient(ServiceClient):
         # TODO: make these requests concurrently.
         return [self.beaker.experiment.get(exp_id) for exp_id in exp_ids or []]
 
+    def export_experiments(self, group: Union[str, Group]) -> str:
+        """
+        Export all experiments and metrics in a group as a CSV.
+
+        :param group: The group ID, name, or object.
+
+        :raises GroupNotFound: If the group can't be found.
+        :raises BeakerError: Any other :class:`~beaker.exceptions.BeakerError` type that can occur.
+        :raises HTTPError: Any other HTTP exception that can occur.
+        """
+        group_id = self.resolve_group(group).id
+        return self.request(
+            f"groups/{self.url_quote(group_id)}/export.csv",
+            method="GET",
+            exceptions_for_status={404: GroupNotFound(self._not_found_err_msg(group))},
+        ).text
+
     def url(self, group: Union[str, Group]) -> str:
         """
         Get the URL for a group.

--- a/beaker/services/group.py
+++ b/beaker/services/group.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import Generator, List, Optional, Union
 
 from ..data_model import *
 from ..exceptions import *
@@ -190,25 +190,40 @@ class GroupClient(ServiceClient):
         # TODO: make these requests concurrently.
         return [self.beaker.experiment.get(exp_id) for exp_id in exp_ids or []]
 
-    def export_experiments(self, group: Union[str, Group]) -> Generator[bytes, None, None]:
+    def export_experiments(
+        self, group: Union[str, Group], quiet: bool = False
+    ) -> Generator[bytes, None, None]:
         """
         Export all experiments and metrics in a group as a CSV.
-        
+
         Returns a generator that should be exhausted to get the complete file.
 
         :param group: The group ID, name, or object.
+        :param quiet: If ``True``, progress won't be displayed.
 
         :raises GroupNotFound: If the group can't be found.
         :raises BeakerError: Any other :class:`~beaker.exceptions.BeakerError` type that can occur.
         :raises HTTPError: Any other HTTP exception that can occur.
         """
         group_id = self.resolve_group(group).id
-        yield from self.request(
+        resp = self.request(
             f"groups/{self.url_quote(group_id)}/export.csv",
             method="GET",
             exceptions_for_status={404: GroupNotFound(self._not_found_err_msg(group))},
-            stream=True
+            stream=True,
         ).iter_content(chunk_size=1024)
+
+        from ..progress import get_group_experiments_progress
+
+        with get_group_experiments_progress(quiet) as progress:
+            task_id = progress.add_task("Downloading:")
+            total = 0
+            for chunk in resp:
+                if chunk:
+                    advance = len(chunk)
+                    total += advance
+                    progress.update(task_id, total=total + 1, advance=advance)
+                    yield chunk
 
     def url(self, group: Union[str, Group]) -> str:
         """

--- a/tests/group_test.py
+++ b/tests/group_test.py
@@ -16,8 +16,9 @@ def test_group_methods(
 
     # Export the experiments from the group
     # (expect a three line CSV: the header, one experiment, and a trailing newline)
-    export = client.group.export_experiments(group)
-    assert len(export.split("\n")) == 3
+    export = list(client.group.export_experiments(group))
+    assert len(export) == 1
+    assert len(export[0].decode().split("\n")) == 3
 
     # Remove the experiment from the group.
     client.group.remove_experiments(group, hello_world_experiment_id)

--- a/tests/group_test.py
+++ b/tests/group_test.py
@@ -14,6 +14,11 @@ def test_group_methods(
     client.group.add_experiments(group, hello_world_experiment_id)
     assert len(client.group.list_experiments(group)) == 1
 
+    # Export the experiments from the group
+    # (expect a three line CSV: the header, one experiment, and a trailing newline)
+    export = client.group.export_experiments(group)
+    assert len(export.split("\n")) == 3
+
     # Remove the experiment from the group.
     client.group.remove_experiments(group, hello_world_experiment_id)
     assert len(client.group.list_experiments(group)) == 0


### PR DESCRIPTION
<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #106 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds a new `export_experiments` method to `GroupClient` that calls the new CSV endpoint.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [x] All GitHub Actions jobs for my pull request have passed.
