### PR TITLE
Handle unknown config fields gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed bug in loading config where encountering unknown fields would cause an exception.
+  `beaker-py` now gracefully handles this.
+
 ## [v1.4.1](https://github.com/allenai/beaker-py/releases/tag/v1.4.1) - 2022-06-10
 
 ### Added

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,6 +1,19 @@
+import pytest
+import yaml
+
 from beaker import Beaker
+from beaker.config import Config
 
 
 def test_str_method(client: Beaker):
     assert "user_token=***" in str(client.config)
     assert client.config.user_token not in str(client.config)
+
+
+def test_config_from_path_unknown_field(tmp_path):
+    path = tmp_path / "config.yml"
+    with open(path, "w") as f:
+        yaml.dump({"user_token": "foo-bar", "baz": 1}, f)
+
+    with pytest.warns(RuntimeWarning, match="Unknown field 'baz' found in config"):
+        Config.from_path(path)


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #125 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Handle unknown config fields gracefully. Warn but don't crash.
- Also adds `default_image` to known config fields.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
