### PR TITLE
Add `.follow()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `Beaker.job.follow()` and `Beaker.experiment.follow()` methods for live streaming logs.
+
+### Changed
+
+- The return type of `Beaker.experiment.tasks()` behaves like both a `Sequence[Task]` and a `Mapping[str, Task]`, i.e.
+  you can call `__getitem__()` with either an `int`, `slice`, or a `str` for the name of a task.
+
+### Fixed
+
+- Fixed a bug where `Beaker.(job|experiment).(wait_for|as_completed)()` methods could hang if a job was canceled or failed to ever start for some reason.
+
 ## [v1.5.1](https://github.com/allenai/beaker-py/releases/tag/v1.5.1) - 2022-06-16
 
 ### Changed

--- a/beaker/conftest.py
+++ b/beaker/conftest.py
@@ -18,6 +18,7 @@ def doctest_fixtures(
     beaker_node_id,
     secret_name,
     group_name,
+    hello_world_experiment_name,
 ):
     doctest_namespace["beaker"] = client
     doctest_namespace["workspace_name"] = workspace_name
@@ -33,3 +34,4 @@ def doctest_fixtures(
     doctest_namespace["beaker_node_id"] = beaker_node_id
     doctest_namespace["secret_name"] = secret_name
     doctest_namespace["group_name"] = group_name
+    doctest_namespace["hello_world_experiment_name"] = hello_world_experiment_name

--- a/beaker/data_model/__init__.py
+++ b/beaker/data_model/__init__.py
@@ -1,5 +1,5 @@
 from .account import *
-from .base import BaseModel
+from .base import BaseModel, MappedSequence
 from .cluster import *
 from .dataset import *
 from .experiment import *

--- a/beaker/data_model/base.py
+++ b/beaker/data_model/base.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Any, Dict, Type, TypeVar
+from typing import Any, Dict, Iterator, Mapping, Sequence, Type, TypeVar, Union
 
 from pydantic import BaseModel as _BaseModel
 from pydantic import ValidationError, root_validator
@@ -72,3 +72,35 @@ class BaseModel(_BaseModel):
             return [cls.jsonify(x_i) for x_i in x]
         else:
             return x
+
+
+class MappedSequence(Sequence[T], Mapping[str, T]):
+    def __init__(self, sequence: Sequence[T], mapping: Mapping[str, T]):
+        self._sequence = sequence
+        self._mapping = mapping
+
+    def __getitem__(self, k) -> Union[T, Sequence[T]]:  # type: ignore[override]
+        if isinstance(k, (int, slice)):
+            return self._sequence[k]
+        elif isinstance(k, str):
+            return self._mapping[k]
+        else:
+            raise TypeError("keys must be integers, slices, or strings")
+
+    def __contains__(self, k) -> bool:
+        if isinstance(k, str):
+            return k in self._mapping
+        else:
+            return k in self._sequence
+
+    def __iter__(self) -> Iterator[T]:
+        return iter(self._sequence)
+
+    def __len__(self) -> int:
+        return len(self._sequence)
+
+    def keys(self):
+        return self._mapping.keys()
+
+    def values(self):
+        return self._mapping.values()

--- a/beaker/data_model/experiment.py
+++ b/beaker/data_model/experiment.py
@@ -1,10 +1,10 @@
 from datetime import datetime
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 from pydantic import Field
 
 from .account import Account
-from .base import BaseModel
+from .base import BaseModel, MappedSequence
 from .job import Job
 from .workspace import WorkspaceRef
 
@@ -48,6 +48,16 @@ class Task(BaseModel):
         if not self.jobs:
             return None
         return sorted(self.jobs, key=lambda job: job.status.created)[-1]
+
+
+class Tasks(MappedSequence[Task]):
+    """
+    A sequence of :class:`Task` that also behaves like a mapping of task names to tasks,
+    i.e. you can use ``get()`` or ``__getitem__()`` with the name of the task.
+    """
+
+    def __init__(self, tasks: List[Task]):
+        super().__init__(tasks, {task.name: task for task in tasks if task.name is not None})
 
 
 class ExperimentsPage(BaseModel):

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -175,7 +175,7 @@ Experiment
 ~~~~~~~~~~
 
 .. automodule:: beaker.data_model.experiment
-   :members: Experiment, Task
+   :members: Experiment, Task, Tasks
    :undoc-members:
 
 Secret

--- a/tests/data_model_test.py
+++ b/tests/data_model_test.py
@@ -106,3 +106,16 @@ def test_digest_hashable():
     digest = Digest("0Q/XIPetp+QFDce6EIYNVcNTCZSlPqmEfVs1eFEMK0Y=")
     d = {digest: 1}
     assert digest in d
+
+
+def test_mapped_sequence():
+    ms = MappedSequence([1, 2, 3], {"a": 1, "b": 2, "c": 3})
+    assert ms["a"] == 1
+    assert ms[0] == 1
+    assert len(ms) == 3
+    assert "a" in ms
+    assert 1 in ms
+    assert list(ms) == [1, 2, 3]
+    assert set(ms.keys()) == {"a", "b", "c"}
+    assert ms.get("a") == 1
+    assert "z" not in ms


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds `Beaker.job.follow()` and `Beaker.experiment.follow()` methods for live streaming logs until an experiment/job completes (or fails).
- Fixes a bug where the `.wait_for()` and `.as_completed()` methods could hang if a job was canceled or failed without ever starting.
- Changes the return type of `Beaker.experiment.tasks()` in a backwards compatible way. It used to be `List[Task]`, now it's a `Sequence[Task]` that also behaves like `Mapping[str, Task]` so that you can call `__getitem__()` with the name of a task.

  For example, if you wanted to get a particular task called "train", you can now just do:
  ```python
  beaker.experiment.tasks(exp)["main"]
  ```
  instead of looping over the list of tasks to find the particular task called "main".

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
