### PR TITLE
Catch empty strings in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Handling empty string values in Beaker config YAML files for compatibility with `beaker` CLI.
+  Any empty string values in a Beaker config YAML file are now converted to `None` when the `Config`
+  object is loaded from the file.
+  On the other hand, if you try to explicitly set the value of a field to an empty string when initializing the `Beaker` client (e.g. `Beaker.from_env(default_org='')`)
+  you'll get a `ValueError`.
+
 ## [v1.6.2](https://github.com/allenai/beaker-py/releases/tag/v1.6.2) - 2022-06-27
 
 ### Fixed

--- a/beaker/client.py
+++ b/beaker/client.py
@@ -93,9 +93,14 @@ class Beaker:
 
         # Ensure default workspace exists.
         if self._config.default_workspace is not None:
+            if self._config.default_workspace == "":
+                raise ValueError("'default_workspace' cannot be an empty string")
             self.workspace.ensure(self._config.default_workspace)
+
         # Validate default org.
         if self._config.default_org is not None:
+            if self._config.default_org == "":
+                raise ValueError("'default_org' cannot be an empty string")
             self.organization.get(self._config.default_org)
 
     def __str__(self) -> str:

--- a/beaker/config.py
+++ b/beaker/config.py
@@ -111,6 +111,7 @@ class Config:
             field_names = {f.name for f in fields(cls)}
             data = yaml.load(config_file, Loader=yaml.SafeLoader)
             for key in list(data.keys()):
+                value = data[key]
                 if key not in field_names:
                     del data[key]
                     warnings.warn(
@@ -118,6 +119,9 @@ class Config:
                         f"If this is a bug, please report it at https://github.com/allenai/beaker-py/issues/new/",
                         RuntimeWarning,
                     )
+                elif isinstance(value, str) and value == "":
+                    # Replace empty strings with `None`
+                    data[key] = None
             return cls(**data)
 
     def save(self, path: Optional[Path] = None):


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

Config fields should never be set to empty strings, but the `beaker` CLI is okay with empty strings in the config file, so we should be too.

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Converts empty strings in a config file to `None` when initializing the `Config` object from file for compatibility with `beaker` CLI.
- Raises a `ValueError` if you try to explicitly set a config value to an empty string. For example, `Beaker.from_env(default_org="")` will result in a `ValueError`.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.
