### PR TITLE
Bigger connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+### Changed
+
+- Increased the size of the connection pool
+
 ## [v1.7.0](https://github.com/allenai/beaker-py/releases/tag/v1.7.0) - 2022-08-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+## [v1.7.0](https://github.com/allenai/beaker-py/releases/tag/v1.7.0) - 2022-08-30
+
 ### Added
 
 - Added argument `include_timestamps: bool` to `Beaker.(job|experiment).follow()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,9 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
-### Changed
-
-- Increased the size of the connection pool
-
 ### Fixed
 
-- Fixed bug with `Beaker.(job|experiment).follow()` where final line was returned.
+- Fixed bug with `Beaker.(job|experiment).follow()` where final line wasn't returned.
 
 ### Removed
 

--- a/beaker/client.py
+++ b/beaker/client.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 from typing import Generator, Optional, Tuple, Union
 
@@ -200,7 +201,7 @@ class Beaker:
             backoff_factor=1,
             status_forcelist=self.RECOVERABLE_SERVER_ERROR_CODES,
         )
-        session.mount("https://", HTTPAdapter(max_retries=retries))
+        session.mount("https://", HTTPAdapter(max_retries=retries, pool_maxsize=os.cpu_count() * 2))
         return session
 
     @contextmanager

--- a/beaker/client.py
+++ b/beaker/client.py
@@ -201,7 +201,7 @@ class Beaker:
             backoff_factor=1,
             status_forcelist=self.RECOVERABLE_SERVER_ERROR_CODES,
         )
-        session.mount("https://", HTTPAdapter(max_retries=retries, pool_maxsize=os.cpu_count() * 2))
+        session.mount("https://", HTTPAdapter(max_retries=retries, pool_maxsize=(os.cpu_count() or 16) * 2))
         return session
 
     @contextmanager

--- a/beaker/client.py
+++ b/beaker/client.py
@@ -201,7 +201,9 @@ class Beaker:
             backoff_factor=1,
             status_forcelist=self.RECOVERABLE_SERVER_ERROR_CODES,
         )
-        session.mount("https://", HTTPAdapter(max_retries=retries, pool_maxsize=(os.cpu_count() or 16) * 2))
+        session.mount(
+            "https://", HTTPAdapter(max_retries=retries, pool_maxsize=(os.cpu_count() or 16) * 2)
+        )
         return session
 
     @contextmanager

--- a/beaker/version.py
+++ b/beaker/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "1"
-_MINOR = "6"
-_PATCH = "9"
+_MINOR = "7"
+_PATCH = "0"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
This should fix thousands of messages like these:
```
Connection pool is full, discarding connection: data.beaker.org. Connection pool size: 10
```