### PR TITLE
Treat 429 errors as recoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+### Fixed
+
+- 429 errors treated as recoverable.
+
 ## [v1.7.2](https://github.com/allenai/beaker-py/releases/tag/v1.7.2) - 2022-09-06
 
 ### Fixed

--- a/beaker/client.py
+++ b/beaker/client.py
@@ -55,7 +55,7 @@ class Beaker:
 
     """
 
-    RECOVERABLE_SERVER_ERROR_CODES = (502, 503, 504)
+    RECOVERABLE_SERVER_ERROR_CODES = (429, 502, 503, 504)
     MAX_RETRIES = 5
     API_VERSION = "v3"
 
@@ -202,7 +202,7 @@ class Beaker:
             read=self.MAX_RETRIES,
             status=self.MAX_RETRIES,
             other=self.MAX_RETRIES,
-            backoff_factor=0.5,
+            backoff_factor=1,
             status_forcelist=self.RECOVERABLE_SERVER_ERROR_CODES,
         )
         session.mount(


### PR DESCRIPTION
Hopefully this address the issue in https://github.com/allenai/tango/issues/386 where we're making too many requests to FileHeap too quickly. 