### PR TITLE
Make the cluster field optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   CACHE_PREFIX: v0  # Change this to invalidate existing cache.
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
   BEAKER_WORKSPACE: ai2/petew-testing
 
 jobs:
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: [3.7]
+        python: [3.8]
         task:
           - name: Lint
             run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+### Changed
+
+- The cluster field in `Job` and `TaskContext` is now optional.
+
 ## [v1.10.3](https://github.com/allenai/beaker-py/releases/tag/v1.10.3) - 2022-09-28
 
 ### Fixed

--- a/beaker/data_model/experiment_spec.py
+++ b/beaker/data_model/experiment_spec.py
@@ -262,7 +262,7 @@ class TaskContext(BaseModel, frozen=False):
         if a task is re-run at a future date.
     """
 
-    cluster: str
+    cluster: Optional[str]
     """
     The full name or ID of a Beaker cluster on which the task should run.
     """

--- a/beaker/data_model/job.py
+++ b/beaker/data_model/job.py
@@ -158,7 +158,7 @@ class Job(BaseModel):
     kind: JobKind
     author: Account
     workspace: str
-    cluster: str
+    cluster: Optional[str]
     status: JobStatus
     execution: Optional[JobExecution] = None
     node: Optional[str] = None

--- a/beaker/services/experiment.py
+++ b/beaker/services/experiment.py
@@ -813,7 +813,8 @@ class ExperimentClient(ServiceClient):
                 if env_var.secret is not None:
                     self.beaker.secret.get(env_var.secret, workspace=workspace)
             # Make sure cluster exists.
-            self.beaker.cluster.get(task.context.cluster)
+            if task.context.cluster:
+                self.beaker.cluster.get(task.context.cluster)
 
     def _latest_job(self, jobs: Sequence[Job], ensure_finalized: bool = False) -> Optional[Job]:
         if ensure_finalized:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- We recently made the cluster field in the spec and in the job API optional in order to support multi-cluster scheduling. This change expresses that in the corresponding Python model. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [x] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

