### PR TITLE
Remove deprecated `url` field from `FileInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+### Removed
+
+- Removed deprecated `url` field from `FileInfo` data model.
+
 ## [v1.13.0](https://github.com/allenai/beaker-py/releases/tag/v1.13.0) - 2022-12-09
 
 ### Added

--- a/beaker/data_model/dataset.py
+++ b/beaker/data_model/dataset.py
@@ -136,11 +136,6 @@ class FileInfo(BaseModel, arbitrary_types_allowed=True):
     The size of the file, if known.
     """
 
-    url: Optional[str] = None
-    """
-    A URL that can be used to directly download the file.
-    """
-
     @validator("digest", pre=True)
     def _validate_digest(cls, v: Union[str, Digest]) -> Digest:
         if isinstance(v, Digest):


### PR DESCRIPTION
Closes #187 