### PR TITLE
Fix issue with fetching large dataset files

### DIFF
--- a/beaker/services/service_client.py
+++ b/beaker/services/service_client.py
@@ -94,7 +94,7 @@ class ServiceClient:
             )
 
             # Log response at DEBUG.
-            if response.text:
+            if (not stream) and len(response.content) < 10000 and response.text:
                 self.logger.debug("RECV %s %s %s - %s", method, url, response, response.text)
             else:
                 self.logger.debug("RECV %s %s %s", method, url, response)

--- a/beaker/services/service_client.py
+++ b/beaker/services/service_client.py
@@ -94,7 +94,7 @@ class ServiceClient:
             )
 
             # Log response at DEBUG.
-            if (not stream) and len(response.content) < 10000 and response.text:
+            if not stream and len(response.content) < 1024 and response.text:
                 self.logger.debug("RECV %s %s %s - %s", method, url, response, response.text)
             else:
                 self.logger.debug("RECV %s %s %s", method, url, response)


### PR DESCRIPTION
Prior to this PR, calls to beaker.Beaker.dataset.fetch that download large binary files would hang for a long time and explode memory usage because response.text manifests the whole file as a string internally.  Now, that will only be called if the file is sufficiently small and not using streaming mode.