### PR TITLE
Fixed `TaskSpec.constraints` to behave like a `dict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+### Fixed
+
+- Fixed `TaskSpec.constraints` to behave like a dictionary for backwards compatibility.
+
 ## [v1.18.1](https://github.com/allenai/beaker-py/releases/tag/v1.18.1) - 2023-03-14
 
 ### Added

--- a/beaker/data_model/base.py
+++ b/beaker/data_model/base.py
@@ -58,7 +58,11 @@ class BaseModel(_BaseModel):
         """
         as_snake_case = {to_snake_case(k): v for k, v in values.items()}
         for key, value in as_snake_case.items():
-            if key not in cls.__fields__ and key not in cls.IGNORE_FIELDS:
+            if (
+                cls.__config__.extra != "allow"
+                and key not in cls.__fields__
+                and key not in cls.IGNORE_FIELDS
+            ):
                 warn_about = (cls.__name__, key)
                 if warn_about not in _VALIDATION_WARNINGS_ISSUED:
                     _VALIDATION_WARNINGS_ISSUED.add(warn_about)

--- a/tests/data_model_test.py
+++ b/tests/data_model_test.py
@@ -150,7 +150,17 @@ def test_task_spec_with_constraint():
     assert task_spec.constraints is not None
     assert task_spec.constraints.cluster == ["ai2/general-cirrascale"]
 
-    task_spec = TaskSpec.new("main")
-    new_task_spec = task_spec.with_constraint(cluster=["ai2/allennlp-cirrascale"])
-    assert new_task_spec.constraints is not None
-    assert new_task_spec.constraints.cluster == ["ai2/allennlp-cirrascale"]
+    # These methods should all be equivalent.
+    for task_spec in (
+        TaskSpec.new("main", constraints={"cluster": ["ai2/general-cirrascale"]}),
+        TaskSpec.new("main", cluster="ai2/general-cirrascale"),
+        TaskSpec.new("main", cluster=["ai2/general-cirrascale"]),
+    ):
+        assert task_spec.constraints is not None
+        assert task_spec.constraints.cluster == ["ai2/general-cirrascale"]
+
+
+def test_constraints_behave_like_dictionaries():
+    c = Constraints()
+    c["cluster"] = ["ai2/general-cirrascale"]
+    assert c.cluster == ["ai2/general-cirrascale"]


### PR DESCRIPTION
For backwards compatibility.

FYI @Lucaweihs 