### PR TITLE
Update `synchronized_start_timeout` to use nanoseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+### Fixed
+
+- Update `synchronized_start_timeout` to send nanoseconds to the Beaker server instead of a string.
+
 ## [v1.26.8](https://github.com/allenai/beaker-py/releases/tag/v1.26.8) - 2024-05-01
 
 - Added new fields `JobStatus.ready`, `JobExecution.replica_rank`, and `JobExecution.replica_group_id`.

--- a/beaker/data_model/experiment_spec.py
+++ b/beaker/data_model/experiment_spec.py
@@ -403,11 +403,11 @@ class TaskSpec(BaseModel, frozen=False):
     Determines if whole experiment should fail if this task failures.
     """
 
-    synchronized_start_timeout: Optional[str] = None
+    synchronized_start_timeout: Optional[int] = None
     """
     If set, jobs in the replicated task will wait to start, up to the specified timeout, 
     until all other jobs are also ready. If the timeout is reached, the job will be canceled.
-    Must be greater than zero and less than or equal to 48 hours.
+    Represented using nanoseconds, must be greater than zero and less than or equal to 48 hours.
     """
 
     @classmethod
@@ -471,6 +471,12 @@ class TaskSpec(BaseModel, frozen=False):
                     constraints.cluster = [cluster]
                 else:
                     constraints = Constraints(cluster=[cluster])
+
+        # Allow setting the timeout using seconds, rather than nanoseconds.
+        synchronized_start_timeout_str = kwargs.pop("synchronized_start_timeout", None)
+        if synchronized_start_timeout_str is not None:
+            synchronized_start_timeout = int(synchronized_start_timeout_str * 1_000_000_000)
+            kwargs["synchronized_start_timeout"] = synchronized_start_timeout
 
         return TaskSpec(
             name=name,


### PR DESCRIPTION
Go represents durations as a string for YAML, but as an int (nanoseconds) for JSON, so `beaker-py` needs to send nanoseconds to the service. I added a workaround such that the user can specify seconds instead to be more ergonomic, but am open to any alternatives.