### PR TITLE
 increase default timeout from 5s to 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ use patch releases for compatibility fixes instead.
 
 ## Unreleased
 
+- Increased Beaker.from_env() default timeout from 5s to 30s
+
 ## [v1.31.2](https://github.com/allenai/beaker-py/releases/tag/v1.31.2) - 2024-07-26
 
 ### Added

--- a/beaker/client.py
+++ b/beaker/client.py
@@ -180,7 +180,7 @@ class Beaker:
     def from_env(
         cls,
         check_for_upgrades: bool = True,
-        timeout: Optional[Union[float, Tuple[float, float]]] = 5.0,
+        timeout: Optional[Union[float, Tuple[float, float]]] = 30.0,
         session: Optional[Union[bool, requests.Session]] = None,
         pool_maxsize: Optional[int] = None,
         user_agent: str = f"beaker-py v{VERSION}",


### PR DESCRIPTION
[Parent ticket](https://github.com/allenai/beaker-py/issues/283#issuecomment-2322168881) & assoc'd [ReOps ticket](https://github.com/allenai/beaker/issues/5320#issuecomment-2322286195)

TLDR = `beaker.experiment.list()` take take ~15 seconds depending on query, so let's increase the default timeout.