### PR TITLE
Point to beaker repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@
 <br/>
 </div>
 
+<hr/>
+
+❗ NOTICE: this project has moved! The latest version of beaker-py is now maintained in [allenai/beaker](https://github.com/allenai/beaker/tree/main/bindings/python).
+
+<hr/>
+
 ## Features
 
 <!-- start features -->


### PR DESCRIPTION
As of https://github.com/allenai/beaker/pull/6478, beaker-py will be maintained within the Beaker project. We should also take down the readthedocs deployment.